### PR TITLE
[review] Support locals as render options

### DIFF
--- a/lib/html2pdf/rails/rendering.rb
+++ b/lib/html2pdf/rails/rendering.rb
@@ -37,7 +37,7 @@ module Html2Pdf
         options = _html2pdf_default_options(pdf_name, options)
 
         if options[:show_as_html]
-          render_opts = options.slice(:template, :layout, :formats, :handlers)
+          render_opts = options.slice(:template, :layout, :formats, :handlers, :locals)
           render(render_opts.merge({ content_type: 'text/html' }))
         else
           pdf_content = _html2pdf_make_pdf(options)


### PR DESCRIPTION
model内で`render_pdf_and_get_url`を呼ぶ場合、インスタンス変数を使ってviewにデータを渡せないため、localsを使う必要があります。
このユースケースに対応するためのPRです。

```ruby
# in models

# NG
# @message = 'Hello, world'

ApplicationController.new.render_pdf_and_get_url(
  pdf: ...,
  layout: ...,
  template: ...,
  locals: { message: 'Hello, world' }
)
```